### PR TITLE
Clean up placeholder comments in configuration and code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-# Replace with your credentials!
 DATABASE_URL="postgres://user:password@host:port/db-name"
 VITE_SUPABASE_URL="https://example-url.supabase.co"
 VITE_SUPABASE_ANON_KEY="example-supabase-anaon-key"

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -10,13 +10,11 @@
 
 <Sidebar {user} {houses}>
 	<div class="relative h-full w-full">
-		<!-- Loader with fade animation -->
 		<div
 			class="pointer-events-none absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-300"
 			class:opacity-100={navigating.complete}
 			class:opacity-0={!navigating.complete}
 		>
-			<!-- Gradient blurred spinner -->
 			<div class="relative aspect-square w-12 animate-spin rounded-full">
 				<div
 					class="absolute inset-0 rounded-full bg-gradient-to-tr from-blue-400 via-purple-500 to-pink-500"


### PR DESCRIPTION
Remove unnecessary placeholder comments from the `.env.example` file and eliminate loader comments in the code for improved clarity and cleaner code structure.